### PR TITLE
Add intersphinx mapping for docs

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -84,7 +84,13 @@ html_context = {'display_github': True,
 # :py:mod:`multiprocessing` to link straight to the Python docs of that module.
 # List all available references:
 #   python -msphinx.ext.intersphinx https://docs.python.org/3/objects.inv
-#intersphinx_mapping = {
-#    #'python': ('https://docs.python.org/3', None),
+extensions.append('sphinx.ext.intersphinx')
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
 #    #'sphinx': ('https://www.sphinx-doc.org/', None),
-#    }
+#    #'numpy': ('https://numpy.org/doc/stable/', None),
+#    #'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+#    #'pandas': ('https://pandas.pydata.org/docs/', None),
+#    #'matplotlib': ('https://matplotlib.org/', None),
+#    #'seaborn': ('https://seaborn.pydata.org/', None),
+}

--- a/content/python-basics.md
+++ b/content/python-basics.md
@@ -49,7 +49,7 @@ print(1.0 - some_fraction)
 ```
 
 - Python is **dynamically typed**:
-  We do not have to define that an integer is an `int`, we can use it this way
+  We do not have to define that an integer is an {py:class}`int`, we can use it this way
   and Python will infer it
 - However, one can use type annotations in function definitions
 - Now you also know that we can add `# comments` to our code
@@ -81,9 +81,11 @@ print(experiment["date"])
 experiment["instrument"] = "a particular brand"
 print(experiment)
 ```
-
-- **Sets** are useful for unordered collections where you want to make sure that there are no repetitions.
-- There are also **tuples** that are similar to lists but their items cannot be modified.
+- {py:class}`Lists <list>` are good when order is important, and it
+  needs to be changed
+- {py:class}`Dictionaries <dict>` are mappings key→value.
+- {py:class}`Sets <set>` are useful for unordered collections where you want to make sure that there are no repetitions.
+- There are also {py:class}`tuples <tuple>` that are similar to lists but their items cannot be modified.
 
 You can put:
 - dictionaries inside lists
@@ -302,7 +304,7 @@ which we didn't mention above.
 The function `sorted` sorts a sequence but it creates a new sequence.
 This is useful if you need a sorted result without changing the original sequence.
 
-We could have achieved the same result with `new_sequence.sort()`.
+We could have achieved the same result with {py:meth}`list.sort`.
 
 ```python
 def remove_duplicates_and_sort(sequence):


### PR DESCRIPTION
- Killer feature: easy linking to docs?  This is more a demo than
  anything, but also adds more template stuff from sphinx-lesson for
  your converience.
- List all reference targets with (for example, for Python)
  `python -msphinx.ext.intersphinx https://docs.python.org/3/objects.inv | less`
- Enable more in conf.py.
- Review:
  - General check, this is more a demo than anything (so I can
    properly add it to the docs)